### PR TITLE
Titre de la page du plugin

### DIFF
--- a/index.php
+++ b/index.php
@@ -81,8 +81,8 @@ class adminFakeMeUp
         '<body>' .
         dcPage::breadcrumb(
             [
-                html::escapeHTML(dcCore::app()->blog->name) => '',
-                __('Fake Me Up')                            => '',
+                __('System')             => '',
+                __('Fake Me Up')         => '',
             ]
         ) .
         dcPage::notices();


### PR DESCRIPTION
Puisque le plugin est dans le menu Système, le fil d’Ariane devrait être le même que pour les autres éléments de ce menu (sysInfo par exemple) 